### PR TITLE
Get ground truth

### DIFF
--- a/ros2_ws/src/car_like_mobile_robot_description/urdf/include/gazebo_plugin.xacro
+++ b/ros2_ws/src/car_like_mobile_robot_description/urdf/include/gazebo_plugin.xacro
@@ -6,15 +6,20 @@
     <plugin filename="gz-sim-sensors-system" name="gz::sim::systems::Sensors">
       <render_engine>ogre2</render_engine>
     </plugin>
+
+    <plugin filename="libignition-gazebo-pose-publisher-system.so" name="gz::sim::systems::PosePublisher">
+      <publish_link_pose>false</publish_link_pose>
+      <publish_sensor_pose>true</publish_sensor_pose>
+      <publish_collision_pose>false</publish_collision_pose>
+      <publish_visual_pose>false</publish_visual_pose>
+      <publish_nested_model_pose>true</publish_nested_model_pose>
+      <use_pose_vector_msg>true</use_pose_vector_msg>
+      <!-- <static_publisher>true</static_publisher> -->
+      <static_update_frequency>30</static_update_frequency>
+    </plugin>
   </gazebo>
 
-  <plugin filename="libgazebo_ros_pose.so" name="gazebo_ros_pose">
-    <ros>
-      <namespace>/car_like_mobile_robot</namespace>
-      <remapping>pose:=odom</remapping>
-    </ros>
-    <update_rate>50</update_rate>
-  </plugin>
+  
 
   <!-- IMU PLUGIN  -->
   <!-- <gazebo reference="imu_link">

--- a/ros2_ws/src/car_like_mobile_robot_gazebo/CMakeLists.txt
+++ b/ros2_ws/src/car_like_mobile_robot_gazebo/CMakeLists.txt
@@ -8,12 +8,26 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(ros_gz_sim REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(std_msgs REQUIRED)
+
+include_directories(include)
+
+add_executable(state_variable_pub src/state_variable_pub.cpp)
+
+ament_target_dependencies(state_variable_pub rclcpp std_msgs)
 
 install(
   DIRECTORY 
   launch
   config
+  # state_variable_pub
   DESTINATION share/${PROJECT_NAME}
+)
+
+install(TARGETS
+  state_variable_pub
+  DESTINATION lib/${PROJECT_NAME}
 )
 
 ament_package()

--- a/ros2_ws/src/car_like_mobile_robot_gazebo/CMakeLists.txt
+++ b/ros2_ws/src/car_like_mobile_robot_gazebo/CMakeLists.txt
@@ -10,12 +10,13 @@ find_package(ament_cmake REQUIRED)
 find_package(ros_gz_sim REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
-
+find_package(sensor_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
 include_directories(include)
 
 add_executable(state_variable_pub src/state_variable_pub.cpp)
 
-ament_target_dependencies(state_variable_pub rclcpp std_msgs)
+ament_target_dependencies(state_variable_pub rclcpp sensor_msgs geometry_msgs)
 
 install(
   DIRECTORY 

--- a/ros2_ws/src/car_like_mobile_robot_gazebo/config/gz_bridge.yaml
+++ b/ros2_ws/src/car_like_mobile_robot_gazebo/config/gz_bridge.yaml
@@ -12,7 +12,7 @@
   direction: GZ_TO_ROS
 
 # gz topic published by pose plugin
-- ros_topic_name: "car_likemobile_robot/pose"
+- ros_topic_name: "ground_truth"
   gz_topic_name: "/model/car_like_mobile_robot/pose"
   ros_type_name: "geometry_msgs/msg/PoseArray"
   gz_type_name: "gz.msgs.Pose_V"

--- a/ros2_ws/src/car_like_mobile_robot_gazebo/config/gz_bridge.yaml
+++ b/ros2_ws/src/car_like_mobile_robot_gazebo/config/gz_bridge.yaml
@@ -10,3 +10,10 @@
   ros_type_name: "sensor_msgs/msg/JointState"
   gz_type_name: "gz.msgs.Model"
   direction: GZ_TO_ROS
+
+# gz topic published by pose plugin
+- ros_topic_name: "car_likemobile_robot/pose"
+  gz_topic_name: "/model/car_like_mobile_robot/pose"
+  ros_type_name: "geometry_msgs/msg/PoseArray"
+  gz_type_name: "gz.msgs.Pose_V"
+  direction: GZ_TO_ROS

--- a/ros2_ws/src/car_like_mobile_robot_gazebo/config/state_variable_pub_config.yaml
+++ b/ros2_ws/src/car_like_mobile_robot_gazebo/config/state_variable_pub_config.yaml
@@ -1,0 +1,3 @@
+state_variable_pub:
+  ros__parameters:
+    publish_rate: 50.0  # タイマー周期（秒単位）

--- a/ros2_ws/src/car_like_mobile_robot_gazebo/include/car_like_mobile_robot_gazebo/state_variable_pub.hpp
+++ b/ros2_ws/src/car_like_mobile_robot_gazebo/include/car_like_mobile_robot_gazebo/state_variable_pub.hpp
@@ -4,6 +4,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <geometry_msgs/msg/pose_array.hpp>
 #include <sensor_msgs/msg/joint_state.hpp>
+#include <std_msgs/msg/float64_multi_array.hpp>
 #include <string>
 
 
@@ -19,7 +20,7 @@ private:
 
     rclcpp::Subscription<geometry_msgs::msg::PoseArray>::SharedPtr ground_truth_sub_;
     rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr joint_states_sub_;
-    // rclcpp::Publisher<std_msgs::msg::String>::SharedPtr publisher_;
+    rclcpp::Publisher<std_msgs::msg::Float64MultiArray>::SharedPtr state_variable_pub_;
     rclcpp::TimerBase::SharedPtr timer_;
 
     double x_;

--- a/ros2_ws/src/car_like_mobile_robot_gazebo/include/car_like_mobile_robot_gazebo/state_variable_pub.hpp
+++ b/ros2_ws/src/car_like_mobile_robot_gazebo/include/car_like_mobile_robot_gazebo/state_variable_pub.hpp
@@ -1,0 +1,24 @@
+#ifndef SUB_PUB_NODE_HPP_
+#define SUB_PUB_NODE_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/string.hpp>
+#include <string>
+
+class SubPubNode : public rclcpp::Node
+{
+public:
+    SubPubNode();
+
+private:
+    void topic_callback(const std_msgs::msg::String::SharedPtr msg);
+    void timer_callback();
+
+    rclcpp::Subscription<std_msgs::msg::String>::SharedPtr subscription_;
+    rclcpp::Publisher<std_msgs::msg::String>::SharedPtr publisher_;
+    rclcpp::TimerBase::SharedPtr timer_;
+
+    std::string latest_data_;
+};
+
+#endif  // SUB_PUB_NODE_HPP_

--- a/ros2_ws/src/car_like_mobile_robot_gazebo/include/car_like_mobile_robot_gazebo/state_variable_pub.hpp
+++ b/ros2_ws/src/car_like_mobile_robot_gazebo/include/car_like_mobile_robot_gazebo/state_variable_pub.hpp
@@ -2,8 +2,10 @@
 #define SUB_PUB_NODE_HPP_
 
 #include <rclcpp/rclcpp.hpp>
-#include <std_msgs/msg/string.hpp>
+#include <geometry_msgs/msg/pose_array.hpp>
+#include <sensor_msgs/msg/joint_state.hpp>
 #include <string>
+
 
 class SubPubNode : public rclcpp::Node
 {
@@ -11,13 +13,19 @@ public:
     SubPubNode();
 
 private:
-    void topic_callback(const std_msgs::msg::String::SharedPtr msg);
+    void groundTruthCallback(const geometry_msgs::msg::PoseArray::SharedPtr msg);
+    void jointStatesCallback(const sensor_msgs::msg::JointState::SharedPtr msg);
     void timer_callback();
 
-    rclcpp::Subscription<std_msgs::msg::String>::SharedPtr subscription_;
-    rclcpp::Publisher<std_msgs::msg::String>::SharedPtr publisher_;
+    rclcpp::Subscription<geometry_msgs::msg::PoseArray>::SharedPtr ground_truth_sub_;
+    rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr joint_states_sub_;
+    // rclcpp::Publisher<std_msgs::msg::String>::SharedPtr publisher_;
     rclcpp::TimerBase::SharedPtr timer_;
 
+    double x_;
+    double y_;
+    double theta_;
+    double phi_;
     std::string latest_data_;
 };
 

--- a/ros2_ws/src/car_like_mobile_robot_gazebo/package.xml
+++ b/ros2_ws/src/car_like_mobile_robot_gazebo/package.xml
@@ -14,6 +14,8 @@
 
   <exec_depend>ros_gz</exec_depend>
   <exec_depend>ros_gz_sim</exec_depend>
+  <depend>rclcpp</depend>
+  <depend>std_msgs</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/ros2_ws/src/car_like_mobile_robot_gazebo/src/state_variable_pub.cpp
+++ b/ros2_ws/src/car_like_mobile_robot_gazebo/src/state_variable_pub.cpp
@@ -1,14 +1,18 @@
 #include "car_like_mobile_robot_gazebo/state_variable_pub.hpp"
 
-SubPubNode::SubPubNode() : Node("state_variable_pub"), latest_data_("No data yet")
+SubPubNode::SubPubNode() : Node("state_variable_pub"), x_(0.0), y_(0.0), theta_(0.0), phi_(0.0)
 {
     // サブスクライバーを作成
-    subscription_ = this->create_subscription<std_msgs::msg::String>(
-        "/input_topic", 10,
-        std::bind(&SubPubNode::topic_callback, this, std::placeholders::_1));
+    ground_truth_sub_= this->create_subscription<geometry_msgs::msg::PoseArray>(
+        "/ground_truth", 1,
+        std::bind(&SubPubNode::groundTruthCallback, this, std::placeholders::_1));
+
+    joint_states_sub_= this->create_subscription<sensor_msgs::msg::JointState>(
+        "/joint_states", 1,
+        std::bind(&SubPubNode::jointStatesCallback, this, std::placeholders::_1));
 
     // パブリッシャーを作成
-    publisher_ = this->create_publisher<std_msgs::msg::String>("/output_topic", 10);
+    // publisher_ = this->create_publisher<std_msgs::msg::String>("/output_topic", 10);
 
     // タイマーを作成（1秒ごとにパブリッシュ）
     timer_ = this->create_wall_timer(
@@ -17,18 +21,32 @@ SubPubNode::SubPubNode() : Node("state_variable_pub"), latest_data_("No data yet
 }
 
 // サブスクライバーのコールバック
-void SubPubNode::topic_callback(const std_msgs::msg::String::SharedPtr msg)
+void SubPubNode::groundTruthCallback(const geometry_msgs::msg::PoseArray::SharedPtr msg)
 {
-    latest_data_ = msg->data;
+    x_ = msg->poses[0].position.x;
+    y_ = msg->poses[0].position.y;
+    theta_ = msg->poses[0].orientation.z;
+}
+
+//[0]:front_left_wheel_joint, [1]:front_right_wheel_joint
+//[2]:front_left_steering_joint, [3]:front_right_steering_joint
+//[4]:rear_left_wheel_joint, [5]:rear_right_wheel_joint
+
+void SubPubNode::jointStatesCallback(const sensor_msgs::msg::JointState::SharedPtr msg)
+{
+    double front_left_steering_angle = msg->position[2];
+    double front_right_steering_angle = msg->position[3];
+
+    phi_ = (front_left_steering_angle + front_right_steering_angle) / 2.0;
+    
 }
 
 // タイマーのコールバック（定期的にパブリッシュ）
 void SubPubNode::timer_callback()
 {
-    auto message = std_msgs::msg::String();
-    message.data = "Published: " + latest_data_;
-    RCLCPP_INFO(this->get_logger(), "Publishing: '%s'", message.data.c_str());
-    publisher_->publish(message);
+    
+    RCLCPP_INFO(this->get_logger(), "x:%.3f, y:%.3f, theta:%.3f, phi:%.3f", x_, y_, theta_, phi_);
+    // publisher_->publish(message);
 }
 
 // メイン関数

--- a/ros2_ws/src/car_like_mobile_robot_gazebo/src/state_variable_pub.cpp
+++ b/ros2_ws/src/car_like_mobile_robot_gazebo/src/state_variable_pub.cpp
@@ -1,0 +1,41 @@
+#include "car_like_mobile_robot_gazebo/state_variable_pub.hpp"
+
+SubPubNode::SubPubNode() : Node("state_variable_pub"), latest_data_("No data yet")
+{
+    // サブスクライバーを作成
+    subscription_ = this->create_subscription<std_msgs::msg::String>(
+        "/input_topic", 10,
+        std::bind(&SubPubNode::topic_callback, this, std::placeholders::_1));
+
+    // パブリッシャーを作成
+    publisher_ = this->create_publisher<std_msgs::msg::String>("/output_topic", 10);
+
+    // タイマーを作成（1秒ごとにパブリッシュ）
+    timer_ = this->create_wall_timer(
+        std::chrono::seconds(1),
+        std::bind(&SubPubNode::timer_callback, this));
+}
+
+// サブスクライバーのコールバック
+void SubPubNode::topic_callback(const std_msgs::msg::String::SharedPtr msg)
+{
+    latest_data_ = msg->data;
+}
+
+// タイマーのコールバック（定期的にパブリッシュ）
+void SubPubNode::timer_callback()
+{
+    auto message = std_msgs::msg::String();
+    message.data = "Published: " + latest_data_;
+    RCLCPP_INFO(this->get_logger(), "Publishing: '%s'", message.data.c_str());
+    publisher_->publish(message);
+}
+
+// メイン関数
+int main(int argc, char *argv[])
+{
+    rclcpp::init(argc, argv);
+    rclcpp::spin(std::make_shared<SubPubNode>());
+    rclcpp::shutdown();
+    return 0;
+}


### PR DESCRIPTION
ground truthとjoint_statesをgazeboから受け取り、/state_variableトピックをパブリッシュするノードの作成

## state_variable_pub
### サブスクライブ
/gournd_truth: gazeboから受け取るロボットの真位置のトピック
/joint_states: gazeboから受け取るロボットのジョイントの状態、状態変数φの計算に必要

## パブリッシュ
/state_variable:std_msgs/msg/float64_multi_array型、車の状態変数のトピック
[0]：x
[1]：y
[2]：theta
[3]：phi
