### PR TITLE
modify steering input calculation

### DIFF
--- a/ros2_ws/src/cmd_vel_driver/include/cmd_vel_driver/cmd_vel_driver.hpp
+++ b/ros2_ws/src/cmd_vel_driver/include/cmd_vel_driver/cmd_vel_driver.hpp
@@ -18,10 +18,6 @@ public:
     CmdVelDriver();
     ~CmdVelDriver();
 
-    // Member functions
-    void calcCommand();
-    void publishCommand();
-
 private:
     // constants
     static constexpr double PI = 3.141592653589793;
@@ -44,6 +40,8 @@ private:
     void initializeSubscribers();
     void initializePublishers();
     void cmdVelCallback(const geometry_msgs::msg::Twist::SharedPtr msg);
+    void calcCommand();
+    void publishCommand();
     void publishSteeringAngles(double phi_l, double phi_r);
     void publishWheelAngularVelocities(double omega_l, double omega_r);
 

--- a/ros2_ws/src/cmd_vel_driver/include/cmd_vel_driver/cmd_vel_driver.hpp
+++ b/ros2_ws/src/cmd_vel_driver/include/cmd_vel_driver/cmd_vel_driver.hpp
@@ -19,13 +19,11 @@ public:
     ~CmdVelDriver();
 
     // Member functions
-    void calcCommand(double dt);
+    void calcCommand();
     void publishCommand();
 
 private:
     // constants
-    // static constexpr int STATE_VARIABLE_DIM = 4;   // 車両型移動ロボットの状態変数
-    // static constexpr int RUNGE_DIM = 4;            // Runge()で計算する状態変数の数
     static constexpr double PI = 3.141592653589793;
     static constexpr double WHEEL_BASE = 1.0;      // 車軸間距離(m) (URDFと統一)
     static constexpr double TREAD_WIDTH = 0.856;   // 左右車輪間距離(m) (URDFと統一)
@@ -34,7 +32,6 @@ private:
     // Member Variables
     rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_sub_;
 
-    double pre_time_;
     double linear_velocity_, angular_z_;
 
     double fl_steering_angle_, fr_steering_angle_;

--- a/ros2_ws/src/cmd_vel_driver/src/cmd_vel_driver.cpp
+++ b/ros2_ws/src/cmd_vel_driver/src/cmd_vel_driver.cpp
@@ -2,7 +2,6 @@
 
 
 CmdVelDriver::CmdVelDriver() : Node("cmd_vel_driver"),
-    pre_time_(0.0),
     linear_velocity_(0.0), angular_z_(0.0),
     fl_steering_angle_(0.0), fr_steering_angle_(0.0),
     rl_linear_velocity_(0.0), rr_linear_velocity_(0.0) {
@@ -25,26 +24,29 @@ void CmdVelDriver::cmdVelCallback(const geometry_msgs::msg::Twist::SharedPtr msg
     angular_z_ = msg->angular.z;
 }
 
-void CmdVelDriver::calcCommand(double dt) {
+void CmdVelDriver::calcCommand() {
 
     double velocity = linear_velocity_; // 後輪間中点の速度
-    double omega    = angular_z_;       // 現在の旋回角速度
+    double omega    = angular_z_;       // 旋回角速度
 
-    double current_r = velocity / omega; // 現在の旋回半径
+    double phi_l = 0.0;
+    double phi_r = 0.0;
+
+    if (fabs(omega) > 1e-6) {
+
+        double r = velocity / omega; // 旋回半径
+
+        phi_l = atan(WHEEL_BASE / (r - (0.5 * TREAD_WIDTH)));
+        phi_r = atan(WHEEL_BASE / (r + (0.5 * TREAD_WIDTH)));
+    }
+
     double omega_l = (velocity - (0.5 * TREAD_WIDTH * omega)) / WHEEL_RADIUS;
     double omega_r = (velocity + (0.5 * TREAD_WIDTH * omega)) / WHEEL_RADIUS;
 
-    double current_phi = atan(WHEEL_BASE / current_r); // 現在の前輪ステアリング角度
-    double future_phi  = current_phi + (omega * dt);   // 未来の前輪ステアリング角度
-
-    double future_r = WHEEL_BASE / tan(future_phi); // 未来の旋回半径
-    double phi_l    = atan(WHEEL_BASE / (future_r - (0.5 * TREAD_WIDTH)));
-    double phi_r    = atan(WHEEL_BASE / (future_r + (0.5 * TREAD_WIDTH)));
-
-    // 未来の前輪ステアリング角度
+    // 前輪ステアリング角度
     fl_steering_angle_ = phi_l;
     fr_steering_angle_ = phi_r;
-    // 現在の後輪回転速度
+    // 後輪回転角速度
     rl_linear_velocity_ = omega_l;
     rr_linear_velocity_ = omega_r;
 }
@@ -71,7 +73,6 @@ void CmdVelDriver::publishWheelAngularVelocities(double omega_l, double omega_r)
     rear_wheel_pub_->publish(msg);
 }
 
-
 int main(int argc, char **argv) {
     rclcpp::init(argc, argv);
 
@@ -79,18 +80,10 @@ int main(int argc, char **argv) {
 
     rclcpp::Rate loop_rate(50);
 
-    rclcpp::Time start_time = cmd_vel_driver->now();
-    double pre_t = 0.0;
-
     while (rclcpp::ok()) {
 
-        double t = (cmd_vel_driver->now() - start_time).seconds();
-        double dt = t - pre_t;
-
-        cmd_vel_driver->calcCommand(dt);  // cmd_velを後輪回転角速度とステアリング角度に変換
+        cmd_vel_driver->calcCommand();    // cmd_velを後輪回転角速度とステアリング角度に変換
         cmd_vel_driver->publishCommand(); // 後輪回転角速度とステアリング角度をpublsih
-
-        pre_t = t;
 
         rclcpp::spin_some(cmd_vel_driver);
         loop_rate.sleep();


### PR DESCRIPTION
#3 で議論した内容を反映

- 旋回半径は前輪と後輪で同じ値を使う
- 不要なメンバ変数を削除
- omegaが小さいときは0割を防ぐためその時点でphi_l, phi_rを0.0に設定